### PR TITLE
fix: :sparkles: select food from weighted distribution

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -236,7 +236,7 @@ function createSnake() {
         x[z] = 250 - z * BLOCK_SIZE + BLOCK_SIZE / 2;
         y[z] = 50 + BLOCK_SIZE / 2;
     }
-    console.log(x, y);
+    console.log(`Snake X: ${x}\nSnake Y: ${y}`);
 }
 
 //draw the game


### PR DESCRIPTION
Modify the use of all randomized input in the game backend

- Use `random.random()` instead of `random.SystemRandom()` NOT for cryptographic or security uses.

  > Warning The pseudo-random generators of this module should not be used for security purposes. For security or cryptographic uses, see the [secrets](https://docs.python.org/3/library/secrets.html#module-secrets) module.

- Use `random.choice()` for selecting food from a random weight distribution.